### PR TITLE
Add support for full networks and named applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Here is a list of all the default variables for this role, which are also availa
 
 # list of rules
 ufw_rules: []
+# list of networks (CIDR notation), default is accept
+ufw_networks: []
+# list of premade ufw application rules, default is accept
+ufw_applications: []
 # /etc/defaut/ufw settings
 ufw_ipv6: 'yes'
 ufw_default_input_policy: DROP
@@ -63,6 +67,13 @@ ufw_state: enabled
       - { port: 22 }
       - { port: 80, rule: allow }
     ufw_default_forward_policy: ACCEPT
+    ufw_networks:
+     - { ip: '127.0.0.1/8' }
+     - { ip: '172.17.42.0/24', rule: deny }
+    ufw_applications:
+     - { name: "WWW Full" }
+     - { name: "IMAP", rule: deny }
+
 ```
 
 ## Testing

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,10 @@
 
 # list of rules
 ufw_rules: []
+# list of networks (CIDR notation)
+ufw_networks: []
+# list of premade ufw application rules
+ufw_applications: []
 # /etc/defaut/ufw settings
 ufw_ipv6: 'yes'
 ufw_default_input_policy: DROP

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,11 +1,31 @@
 ---
 
-- name: Configuring rules
+- name: Configuring port/protocol rules
   ufw: >
     port={{ item.port }}
     rule={{ item.rule if item.rule is defined else "allow" }}
     proto={{ item.proto if item.proto is defined else "any" }}
   with_items: ufw_rules
+  tags:
+    - networking
+    - ufw
+    - config
+
+- name: Configuring network rules
+  ufw: >
+    from_ip="{{ item.ip }}"
+    rule={{ item.rule if item.rule is defined else "allow" }}
+  with_items: ufw_networks
+  tags:
+    - networking
+    - ufw
+    - config
+
+- name: Configuring application rules
+  ufw: >
+    name="{{ item.name }}"
+    rule={{ item.rule if item.rule is defined else "allow" }}
+  with_items: ufw_applications
   tags:
     - networking
     - ufw

--- a/test.yml
+++ b/test.yml
@@ -8,3 +8,9 @@
       - { port: 22 }
       - { port: 80, rule: allow }
     ufw_default_forward_policy: ACCEPT
+    ufw_networks:
+     - { ip: '127.0.0.1/8' }
+     - { ip: '127.0.42.0/24', rule: deny }
+    ufw_applications:
+     - { name: "WWW Full" }
+     - { name: "IMAP", rule: deny }


### PR DESCRIPTION
The existing rules code doesn't allow for a couple of handy features
in UFW, being able to drop netblocks and using pre canned configuration.

Although this system results in largely duplicated code it was better
then the alternative I tried which was to mangle the existing ufw_rules
code to handle all three.

If the new variables are empty, they are skipped. If they contain a list
(optionally with a rule: deny) they are run (the two configurations I've
tested).

I'm not sure if this is something you'd like in the role but as its behaviour i'm using.
