### PR TITLE
Galaxy role name appears to be incorrect in README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 
 script:
   - echo localhost > inventory
-  - ln -s ansible-ufw ../franklinkim.ufw
+  - ln -s ansible-ufw ../weareinteractive.ufw
   - ansible-playbook --syntax-check -i inventory tests/main.yml
   - ansible-playbook -i inventory tests/main.yml --connection=local --sudo -vvvv
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Ansible franklinkim.ufw role
+# Ansible weareinteractive.ufw role
 
 [![Build Status](https://img.shields.io/travis/weareinteractive/ansible-ufw.svg)](https://travis-ci.org/weareinteractive/ansible-ufw)
 [![Galaxy](http://img.shields.io/badge/galaxy-weareinteractive.ufw-blue.svg)](https://galaxy.ansible.com/weareinteractive/ufw)
 [![GitHub Tags](https://img.shields.io/github/tag/weareinteractive/ansible-ufw.svg)](https://github.com/weareinteractive/ansible-ufw)
 [![GitHub Stars](https://img.shields.io/github/stars/weareinteractive/ansible-ufw.svg)](https://github.com/weareinteractive/ansible-ufw)
 
-> `franklinkim.ufw` is an [Ansible](http://www.ansible.com) role which:
+> `weareinteractive.ufw` is an [Ansible](http://www.ansible.com) role which:
 >
 > * installs ufw
 > * configures ufw
@@ -17,19 +17,19 @@
 Using `ansible-galaxy`:
 
 ```shell
-$ ansible-galaxy install franklinkim.ufw
+$ ansible-galaxy install weareinteractive.ufw
 ```
 
 Using `requirements.yml`:
 
 ```yaml
-- src: franklinkim.ufw
+- src: weareinteractive.ufw
 ```
 
 Using `git`:
 
 ```shell
-$ git clone https://github.com/weareinteractive/ansible-ufw.git franklinkim.ufw
+$ git clone https://github.com/weareinteractive/ansible-ufw.git weareinteractive.ufw
 ```
 
 ## Dependencies
@@ -96,7 +96,7 @@ This is an example playbook:
 
 - hosts: all
   roles:
-    - franklinkim.ufw
+    - weareinteractive.ufw
   vars:
     ufw_rules:
       - { port: 22, rule: allow }

--- a/meta/readme.yml
+++ b/meta/readme.yml
@@ -1,6 +1,6 @@
 ---
 
-galaxy_name: franklinkim.ufw
+galaxy_name: weareinteractive.ufw
 github_user: weareinteractive
 github_name: ansible-ufw
 badges: |

--- a/tests/main.yml
+++ b/tests/main.yml
@@ -2,7 +2,7 @@
 
 - hosts: all
   roles:
-    - franklinkim.ufw
+    - weareinteractive.ufw
   vars:
     ufw_rules:
       - { port: 22, rule: allow }


### PR DESCRIPTION
Following the current README usage instructions doesn't work as the Galaxy role name appears to be incorrect (it uses `franklinkim.ufw` when it appears to need to be `weareinteractive.ufw`). This PR fixes that and also updates usage in meta & tests for consistency.